### PR TITLE
Conversion of JSON back to native objects 

### DIFF
--- a/restclient/__init__.py
+++ b/restclient/__init__.py
@@ -112,6 +112,10 @@ def post_multipart(host, selector, method,fields, files, headers=None,return_res
     # if the content-type is JSON, then convert back to objects.
     if resp['content-type'] == 'application/json':
         content = json.loads(content)
+    elif method == 'GET' and content.startswith('{') and content.endswith('}'):
+        content = json.loads(content)
+    elif method == 'GET' and content.startswith('[') and content.endswith(']'):
+        content = json.loads(content)
     if return_resp:
         return resp, content
     else:
@@ -363,6 +367,10 @@ def non_multipart(params,host,method,path,headers,return_resp,scheme="http",cred
     httplib2.debuglevel = orig_debuglevel
     # if the content-type is JSON, then convert back to objects.
     if resp['content-type'] == 'application/json':
+        content = json.loads(content)
+    elif method == 'GET' and content.startswith('{') and content.endswith('}'):
+        content = json.loads(content)
+    elif method == 'GET' and content.startswith('[') and content.endswith(']'):
         content = json.loads(content)
     if return_resp:
         return resp,content

--- a/restclient/__init__.py
+++ b/restclient/__init__.py
@@ -109,6 +109,9 @@ def post_multipart(host, selector, method,fields, files, headers=None,return_res
     resp, content = h.request("%s://%s%s" % (scheme,host,selector),method,body,headers)
     # reset httplib2 debuglevel to original value
     httplib2.debuglevel = orig_debuglevel
+    # if the content-type is JSON, then convert back to objects.
+    if resp['content-type'] == 'application/json':
+        content = json.loads(content)
     if return_resp:
         return resp, content
     else:
@@ -358,6 +361,9 @@ def non_multipart(params,host,method,path,headers,return_resp,scheme="http",cred
     resp,content = h.request(url,method.encode('utf-8'),params.encode('utf-8'),headers)
     # reset httplib2 debuglevel to original value
     httplib2.debuglevel = orig_debuglevel
+    # if the content-type is JSON, then convert back to objects.
+    if resp['content-type'] == 'application/json':
+        content = json.loads(content)
     if return_resp:
         return resp,content
     else:

--- a/restclient/__init__.py
+++ b/restclient/__init__.py
@@ -110,7 +110,7 @@ def post_multipart(host, selector, method,fields, files, headers=None,return_res
     # reset httplib2 debuglevel to original value
     httplib2.debuglevel = orig_debuglevel
     # if the content-type is JSON, then convert back to objects.
-    if resp['content-type'] == 'application/json':
+    if resp['content-type'].startswith('application/json'):
         content = json.loads(content)
     elif method == 'GET' and content.startswith('{') and content.endswith('}'):
         content = json.loads(content)
@@ -366,7 +366,7 @@ def non_multipart(params,host,method,path,headers,return_resp,scheme="http",cred
     # reset httplib2 debuglevel to original value
     httplib2.debuglevel = orig_debuglevel
     # if the content-type is JSON, then convert back to objects.
-    if resp['content-type'] == 'application/json':
+    if resp['content-type'].startswith('application/json'):
         content = json.loads(content)
     elif method == 'GET' and content.startswith('{') and content.endswith('}'):
         content = json.loads(content)


### PR DESCRIPTION
Not sure what I was thinking with the last pull, but sending native objects to be converted to JSON should be converted back from JSON to native objects. I also attempt to capture JSON coming back on a GET call and convert it back to native objects. 
